### PR TITLE
Implement property typehint sniff for private static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 composer.lock
 .phpunit.result.cache
+/app

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Check out the [Wiki](https://github.com/silverstripeltd/bespoke-standards/wiki) 
 ## Custom Silverstripe sniffs 👃
 Check out all of them in our [wiki section](https://github.com/silverstripeltd/bespoke-standards/wiki/Custom-Sniff)  dedicated to them
 - [Silverstripe.Sniffs.Extension.DisallowOwnerPropertySniff](https://github.com/silverstripeltd/bespoke-standards/wiki/Silverstripe-Bespoke-Sniffs#silverstripesniffsextensiondisallowownerpropertysniff)
+- [Silverstripe.Sniffs.Property.TypehintPrivateStaticSniff](https://github.com/silverstripeltd/bespoke-standards/wiki/Silverstripe-Bespoke-Sniffs#silverstripesniffspropertytypehintprivatestaticsniff)
 
 
 ## Maintainers 🤓

--- a/src/Sniffs/Property/TypehintPrivateStaticSniff.php
+++ b/src/Sniffs/Property/TypehintPrivateStaticSniff.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Silverstripe\Sniffs\Property;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\PropertyHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
+use function array_merge;
+use const T_CONST;
+use const T_FUNCTION;
+use const T_PRIVATE;
+use const T_PROTECTED;
+use const T_PUBLIC;
+use const T_STATIC;
+use const T_VAR;
+use const T_VARIABLE;
+
+class TypehintPrivateStaticSniff implements Sniff
+{
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return array(int)
+     */
+    public function register()
+    {
+        return [
+            T_VAR,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_STATIC,
+        ];
+    }
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param File $phpcsFile The current file being checked.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $propertyPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_CONST, T_VARIABLE], $stackPtr + 1);
+
+        if ($propertyPointer === null || $tokens[$propertyPointer]['code'] !== T_VARIABLE) {
+            return;
+        }
+
+        if (!PropertyHelper::isProperty($phpcsFile, $propertyPointer)) {
+            return;
+        }
+
+        $previousPointer = TokenHelper::findPreviousExcluding(
+            $phpcsFile,
+            array_merge(TokenHelper::$ineffectiveTokenCodes, TokenHelper::getTypeHintTokenCodes(), [T_NULLABLE]),
+            $propertyPointer - 1
+        );
+        $propertyStartPointer = TokenHelper::findPrevious($phpcsFile, [T_PRIVATE], $propertyPointer - 1);
+
+        // Skip non-static property
+        if (!($tokens[$previousPointer]['code'] === T_STATIC && $tokens[$propertyStartPointer]['code'] === T_PRIVATE)) {
+            return;
+        }
+
+        // Process property type sniff from SlevomatCodingStandard
+        $sniff = new PropertyTypeHintSniff();
+        $sniff->enableNativeTypeHint = true;
+        $sniff->enableIntersectionTypeHint = true;
+        $sniff->enableMixedTypeHint = true;
+        $sniff->enableStandaloneNullTrueFalseTypeHints = true;
+        $sniff->enableUnionTypeHint = true;
+        $sniff->process($phpcsFile, $stackPtr);
+    }
+
+}

--- a/tests/Sniffs/Property/TypehintPrivateStaticSniffTest.php
+++ b/tests/Sniffs/Property/TypehintPrivateStaticSniffTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Silverstripe\Sniffs\Property;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
+
+class TypehintPrivateStaticSniffTest extends TestCase
+{
+    public function testNoErrors(): void
+    {
+        $report = self::checkFile(
+            __DIR__ . '/data/TypehintPrivateStaticSniff_NoErrors.php',
+        );
+
+        self::assertNoSniffErrorInFile($report);
+    }
+
+    public function testErrors(): void
+    {
+        $report = self::checkFile(
+            __DIR__ . '/data/TypehintPrivateStaticSniff_Errors.php', [
+        ]);
+
+        self::assertSame(7, $report->getErrorCount());
+
+        self::assertSniffError($report, 8, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+        self::assertSniffError($report, 12, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+        self::assertSniffError($report, 16, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+        self::assertSniffError($report, 21, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+        self::assertSniffError($report, 23, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+        self::assertSniffError($report, 24, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+        self::assertSniffError($report, 25, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+        self::assertNoSniffError($report, 29);
+        self::assertNoSniffError($report, 31);
+
+        self::assertAllFixedInFile($report);
+    }
+}

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.fixed.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.fixed.php
@@ -1,0 +1,23 @@
+<?php
+
+class SomeClass
+{
+    /**
+     * @var string[]
+     */
+    private static array $db = [];
+    private static string $table_name = '';
+    private static bool $cool_config = true;
+
+    private static int $cool_config_2 = 1;
+
+    private static $table_name_2 = '';
+    private static $cool_config_3 = true;
+    private static $cool_config_4 = 1;
+    /**
+     * @var string
+     */
+    private $variable = '';
+
+    public function get($var): void {}
+}

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.php
@@ -1,0 +1,32 @@
+<?php
+
+class SomeClass
+{
+    /**
+     * @var string[]
+     */
+    private static $db = [];
+    /**
+     * @var string
+     */
+    private static $table_name = '';
+    /**
+     * @var bool
+     */
+    private static $cool_config = true;
+
+    /**
+     * @var int
+     */
+    private static $cool_config_2 = 1;
+
+    private static $table_name_2 = '';
+    private static $cool_config_3 = true;
+    private static $cool_config_4 = 1;
+    /**
+     * @var string
+     */
+    private $variable = '';
+
+    public function get($var): void {}
+}

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_NoErrors.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_NoErrors.php
@@ -1,0 +1,17 @@
+<?php
+
+class NoErrors
+{
+    /**
+     * @var string[]
+     */
+    private static array $db = [];
+    private static string $table_name = '';
+    private static bool $cool_config = true;
+
+    private static int $cool_config_2 = 1;
+
+    private $variable = '';
+
+    public function get($var): void {}
+}


### PR DESCRIPTION
## Enforce type hint in private static properties


PHP version: `8.1`  
Sniff name: Silverstripe.Sniffs.Proptery.TypehintPrivateStatic

## Description
Fixes issue #12 

## Final checklist for reviewer
- [x] ReadMe updated with Sniff name and link to docs in Wiki
- [x] Unit test(s) added
- [x] Disallowed/Allowed code examples added

