### PR TITLE
Run PHP CodeSniffer in parallel mode by default

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,10 +6,11 @@
     <exclude-pattern>./vendor/*</exclude-pattern>
     <exclude-pattern>*/thirdparty/*</exclude-pattern>
 
-    <!-- Show progress and output sniff names on violation, and add colours -->
+    <!-- Show progress and output sniff names on violation, add colours, and run in parallel mode -->
     <arg value="p" />
     <arg name="colors" />
     <arg value="s" />
+    <arg name="parallel" value="10" />
 
     <!-- Use PSR-2 as a base standard -->
     <rule ref="PSR2">


### PR DESCRIPTION
## Run PHP CodeSniffer in parallel mode

## Description
- Resolves #20

## Usage
- Default value for parallel mode is 10, which should work with most dev and CI environments. This value can be overridden using the `--parallel=X` parameter
- The value parallel mode should be less or equal to the amount of processes available on a given machine. For ddev, the amount of processes available is 12, on CI (Docker medium) the amount is 36

