### PR TITLE
✨ Add report generation scripts

### DIFF
--- a/bespoke-phpcs
+++ b/bespoke-phpcs
@@ -6,6 +6,7 @@ if (count($_SERVER['argv']) >1) {
     die;
 }
 
+$_SERVER['argv'][] =  '-s'; // Include sniff codes
 $_SERVER['argv'][] = 'app'; // scan app folder
 
 // Use rules defined in project root or by default what defined in bespoke standards

--- a/bespoke-phpcs-report-source
+++ b/bespoke-phpcs-report-source
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+if (count($_SERVER['argv']) > 1) {
+    echo "⚠️  Sorry. You passed an extra parameter, this is currently not supported." . PHP_EOL;
+    die;
+}
+
+// source
+$_SERVER['argv'][] =  '--report=source';
+
+$_SERVER['argv'][] = 'app'; // scan app folder
+
+// Use rules defined in project root or by default what defined in bespoke standards
+if (file_exists(__DIR__ . '/../../../phpcs.xml')) {
+    $_SERVER['argv'][] = '--standard=phpcs.xml';
+} else {
+    $_SERVER['argv'][] = '--standard=' . __DIR__ . '/ruleset.xml'; // rules
+}
+$_SERVER['argv'][] = '--extensions=php'; // only php files
+$_SERVER['argv'][] = '--encoding=utf-8';
+
+include __DIR__ . '/../../bin/phpcs';

--- a/bespoke-phpcs-report-source
+++ b/bespoke-phpcs-report-source
@@ -2,7 +2,7 @@
 <?php
 
 if (count($_SERVER['argv']) > 1) {
-    echo "⚠️  Sorry. You passed an extra parameter, this is currently not supported." . PHP_EOL;
+    echo "⚠️ Sorry. Parameters are currently not supported." . PHP_EOL;
     die;
 }
 

--- a/bespoke-phpcs-report-summary
+++ b/bespoke-phpcs-report-summary
@@ -2,7 +2,7 @@
 <?php
 
 if (count($_SERVER['argv']) > 1) {
-    echo "⚠️  Sorry. You passed an extra parameter, this is currently not supported." . PHP_EOL;
+    echo "⚠️ Sorry. Parameters are currently not supported." . PHP_EOL;
     die;
 }
 

--- a/bespoke-phpcs-report-summary
+++ b/bespoke-phpcs-report-summary
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+if (count($_SERVER['argv']) > 1) {
+    echo "⚠️  Sorry. You passed an extra parameter, this is currently not supported." . PHP_EOL;
+    die;
+}
+
+// Summary
+$_SERVER['argv'][] =  '--report=summary';
+
+$_SERVER['argv'][] = 'app'; // scan app folder
+
+// Use rules defined in project root or by default what defined in bespoke standards
+if (file_exists(__DIR__ . '/../../../phpcs.xml')) {
+    $_SERVER['argv'][] = '--standard=phpcs.xml';
+} else {
+    $_SERVER['argv'][] = '--standard=' . __DIR__ . '/ruleset.xml'; // rules
+}
+$_SERVER['argv'][] = '--extensions=php'; // only php files
+$_SERVER['argv'][] = '--encoding=utf-8';
+
+include __DIR__ . '/../../bin/phpcs';

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,8 @@
     "bin": [
         "bespoke-phpcbf",
         "bespoke-phpcs",
+        "bespoke-phpcs-report-source",
+        "bespoke-phpcs-report-summary",
         "bespoke-phplint"
     ],
     "require": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,10 +6,9 @@
     <exclude-pattern>./vendor/*</exclude-pattern>
     <exclude-pattern>*/thirdparty/*</exclude-pattern>
 
-    <!-- Show progress and output sniff names on violation, add colours, and run in parallel mode -->
+    <!-- Show progress, and add colours, and run in parallel mode -->
     <arg value="p" />
     <arg name="colors" />
-    <arg value="s" />
     <arg name="parallel" value="10" />
 
     <!-- Use PSR-2 as a base standard -->


### PR DESCRIPTION
<!-- Update the following example details to be relevant -->

PHP version: `8.0+`  

## Description
Adding two new scripts:
1. `bespoke-phpcs-report-source`
2. `bespoke-phpcs-report-summary`

## Reason for the change
A new usecase from @poyjavier was the ability to see how other PHP code adhears to our coding standards as code review is sometimes a task done.

The ability to do the following
1. Add this project as a dependancy
3. Run a script to get the report
4. Present said report

Will vastly streamline things and gives some reference-able data.

### Note.
Ability to pass these commands dynamically can be looked at in the future.

Also, this is including the error of passed commands that is present in #27 



# Plan for Wiki update post merge:
- [ ] https://github.com/silverstripeltd/bespoke-standards/wiki#usage-
  Adjust this section to include new scripts
- [ ] https://github.com/silverstripeltd/bespoke-standards/wiki/Installation
  Adjust exmaple to include new scripts  



## Final checklist for reviewer
- [ ] ~ReadMe updated with Sniff name and link to~ docs in Wiki
- [ ] ~Unit test(s) added~
- [ ] ~Disallowed/Allowed code examples added~

