### PR TITLE
Force slevomat update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- Update the following example details to be relevant -->
 
-PHP version: `8.1`  
+PHP version: `8.3`  
 Proposed Sniff name: `Silverstripe.Sniffs.Extension.DisallowOwnerPropertySniff`
 
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         },
         {
             "name": "Mo Alsharaf",
-            "email": "margot.robbie@silverstripe.com"
+            "email": "mohamed.alsharaf@silverstripe.com"
         }
     ],
     "bin": [
@@ -23,7 +23,7 @@
         "php": "^8.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "slevomat/coding-standard": "^8.8"
+        "slevomat/coding-standard": "^8.16"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -157,6 +157,12 @@
         <exclude name="SlevomatCodingStandard.Classes.RequireSelfReference.RequiredSelfReference"/>
         <!-- We allow named arguments for methods -->
         <exclude name="SlevomatCodingStandard.Functions.DisallowNamedArguments.DisallowedNamedArgument"/>
+
+        <!-- EXCLUDING DEPRECATED SNIFFS -->
+        <!-- This sniff has been deprecated since Slevomat Coding Standard 8.16.0 and will be removed in Slevomat Coding Standard 9.0.0 -->
+        <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+
+        <!-- End of deprecated sniffs -->
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">


### PR DESCRIPTION
## Update Slevomat

<!-- Update the following example details to be relevant -->

PHP version: `8.2`  


## Description
- misc minor clean up
- bump requirement to ensure updates happen
- remove deprecated sniff.
```
-  SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
   This sniff has been deprecated since Slevomat Coding Standard 8.16.0 and will be removed in Slevomat Coding Standard 9.0.0.
Use SlevomatCodingStandard.TypeHints.DNFTypeHintFormat instead.
```

## Final checklist for reviewer
- [ ] ReadMe updated with Sniff name and link to docs in Wiki
- [ ] Unit test(s) added
- [ ] Disallowed/Allowed code examples added

