### PR TITLE
Disable Silverstripe.Sniffs.Property.TypehintPrivateStaticSniff due to issues

### DIFF
--- a/src/Sniffs/Property/TypehintPrivateStaticSniff.php
+++ b/src/Sniffs/Property/TypehintPrivateStaticSniff.php
@@ -27,13 +27,16 @@ class TypehintPrivateStaticSniff implements Sniff
      */
     public function register()
     {
-        return [
-            T_VAR,
-            T_PUBLIC,
-            T_PROTECTED,
-            T_PRIVATE,
-            T_STATIC,
-        ];
+        // Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
+
+        return [];
+        // return [
+        //     T_VAR,
+        //     T_PUBLIC,
+        //     T_PROTECTED,
+        //     T_PRIVATE,
+        //     T_STATIC,
+        // ];
     }
 
     /**
@@ -44,6 +47,9 @@ class TypehintPrivateStaticSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr): void
     {
+        // Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
+        return;
+
         $tokens = $phpcsFile->getTokens();
 
         $propertyPointer = TokenHelper::findNext($phpcsFile, [T_FUNCTION, T_CONST, T_VARIABLE], $stackPtr + 1);

--- a/tests/Sniffs/Property/TypehintPrivateStaticSniffTest.php
+++ b/tests/Sniffs/Property/TypehintPrivateStaticSniffTest.php
@@ -1,39 +1,41 @@
 <?php
 
-namespace Silverstripe\Sniffs\Property;
+// Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
 
-use SlevomatCodingStandard\Sniffs\TestCase;
-use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
+// namespace Silverstripe\Sniffs\Property;
 
-class TypehintPrivateStaticSniffTest extends TestCase
-{
-    public function testNoErrors(): void
-    {
-        $report = self::checkFile(
-            __DIR__ . '/data/TypehintPrivateStaticSniff_NoErrors.php',
-        );
+// use SlevomatCodingStandard\Sniffs\TestCase;
+// use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 
-        self::assertNoSniffErrorInFile($report);
-    }
+// class TypehintPrivateStaticSniffTest extends TestCase
+// {
+//     public function testNoErrors(): void
+//     {
+//         $report = self::checkFile(
+//             __DIR__ . '/data/TypehintPrivateStaticSniff_NoErrors.php',
+//         );
 
-    public function testErrors(): void
-    {
-        $report = self::checkFile(
-            __DIR__ . '/data/TypehintPrivateStaticSniff_Errors.php', [
-        ]);
+//         self::assertNoSniffErrorInFile($report);
+//     }
 
-        self::assertSame(7, $report->getErrorCount());
+//     public function testErrors(): void
+//     {
+//         $report = self::checkFile(
+//             __DIR__ . '/data/TypehintPrivateStaticSniff_Errors.php', [
+//         ]);
 
-        self::assertSniffError($report, 8, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
-        self::assertSniffError($report, 12, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
-        self::assertSniffError($report, 16, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
-        self::assertSniffError($report, 21, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
-        self::assertSniffError($report, 23, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
-        self::assertSniffError($report, 24, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
-        self::assertSniffError($report, 25, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
-        self::assertNoSniffError($report, 29);
-        self::assertNoSniffError($report, 31);
+//         self::assertSame(7, $report->getErrorCount());
 
-        self::assertAllFixedInFile($report);
-    }
-}
+//         self::assertSniffError($report, 8, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+//         self::assertSniffError($report, 12, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+//         self::assertSniffError($report, 16, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+//         self::assertSniffError($report, 21, PropertyTypeHintSniff::CODE_MISSING_NATIVE_TYPE_HINT);
+//         self::assertSniffError($report, 23, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+//         self::assertSniffError($report, 24, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+//         self::assertSniffError($report, 25, PropertyTypeHintSniff::CODE_MISSING_ANY_TYPE_HINT);
+//         self::assertNoSniffError($report, 29);
+//         self::assertNoSniffError($report, 31);
+
+//         self::assertAllFixedInFile($report);
+//     }
+// }

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.fixed.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.fixed.php
@@ -1,23 +1,24 @@
 <?php
+// Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
 
-class SomeClass
-{
-    /**
-     * @var string[]
-     */
-    private static array $db = [];
-    private static string $table_name = '';
-    private static bool $cool_config = true;
+// class SomeClass
+// {
+//     /**
+//      * @var string[]
+//      */
+//     private static array $db = [];
+//     private static string $table_name = '';
+//     private static bool $cool_config = true;
 
-    private static int $cool_config_2 = 1;
+//     private static int $cool_config_2 = 1;
 
-    private static $table_name_2 = '';
-    private static $cool_config_3 = true;
-    private static $cool_config_4 = 1;
-    /**
-     * @var string
-     */
-    private $variable = '';
+//     private static $table_name_2 = '';
+//     private static $cool_config_3 = true;
+//     private static $cool_config_4 = 1;
+//     /**
+//      * @var string
+//      */
+//     private $variable = '';
 
-    public function get($var): void {}
-}
+//     public function get($var): void {}
+// }

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_Errors.php
@@ -1,32 +1,34 @@
 <?php
 
-class SomeClass
-{
-    /**
-     * @var string[]
-     */
-    private static $db = [];
-    /**
-     * @var string
-     */
-    private static $table_name = '';
-    /**
-     * @var bool
-     */
-    private static $cool_config = true;
+// Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
 
-    /**
-     * @var int
-     */
-    private static $cool_config_2 = 1;
+// class SomeClass
+// {
+//     /**
+//      * @var string[]
+//      */
+//     private static $db = [];
+//     /**
+//      * @var string
+//      */
+//     private static $table_name = '';
+//     /**
+//      * @var bool
+//      */
+//     private static $cool_config = true;
 
-    private static $table_name_2 = '';
-    private static $cool_config_3 = true;
-    private static $cool_config_4 = 1;
-    /**
-     * @var string
-     */
-    private $variable = '';
+//     /**
+//      * @var int
+//      */
+//     private static $cool_config_2 = 1;
 
-    public function get($var): void {}
-}
+//     private static $table_name_2 = '';
+//     private static $cool_config_3 = true;
+//     private static $cool_config_4 = 1;
+//     /**
+//      * @var string
+//      */
+//     private $variable = '';
+
+//     public function get($var): void {}
+// }

--- a/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_NoErrors.php
+++ b/tests/Sniffs/Property/data/TypehintPrivateStaticSniff_NoErrors.php
@@ -1,17 +1,19 @@
 <?php
 
-class NoErrors
-{
-    /**
-     * @var string[]
-     */
-    private static array $db = [];
-    private static string $table_name = '';
-    private static bool $cool_config = true;
+// Disabling until fixed in https://github.com/silverstripeltd/bespoke-standards/pull/33
 
-    private static int $cool_config_2 = 1;
+// class NoErrors
+// {
+//     /**
+//      * @var string[]
+//      */
+//     private static array $db = [];
+//     private static string $table_name = '';
+//     private static bool $cool_config = true;
 
-    private $variable = '';
+//     private static int $cool_config_2 = 1;
 
-    public function get($var): void {}
-}
+//     private $variable = '';
+
+//     public function get($var): void {}
+// }


### PR DESCRIPTION
PR purpose to disable the issues covered in https://github.com/silverstripeltd/bespoke-standards/issues/32 for now

Once merged we can release as `1.4.1` and people can not be locked to a `1.3.x` version