### PR TITLE
fix invalid rule config

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -168,7 +168,9 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
             <property name="searchAnnotations" type="bool" value="true"/>
-            <property name="ignoredAnnotationNames" type="array" value="@config"/>
+            <property name="ignoredAnnotationNames" type="array">
+                <element value="@config"/>
+            </property>
         </properties>
     </rule>
 


### PR DESCRIPTION
fixes the following error:

```
ERROR: Passing an array of values to a property using a comma-separated string
is no longer supported since PHP_CodeSniffer 4.0.0.
The unsupported syntax was used for property "ignoredAnnotationNames"
for sniff "SlevomatCodingStandard.Namespaces.UnusedUses".
Pass array values via <element [key="..." ]value="..."> nodes instead.
```

## {{ Title for your PR }}

<!-- Update the following example details to be relevant -->

PHP version: `8.3`  
Proposed Sniff name: `Silverstripe.Sniffs.Extension.DisallowOwnerPropertySniff`


## Description
{{ General description about the change }}

## Reason for the change

- {{ Reason 1 }}
- {{ Reason 2 }}
- {{ etc }}


## Disallowed Code Example

```diff
class MyClass {

-   public function do_cool_thing() {
    
    }
}
```
## Allowed Code Example

```diff 
class MyClass {

+   public function doCoolThing() {
    
    }
}
```

## Usage

{{ Describe how to use the Sniff. How to exclude and how to customise it if possible/required }}


## Final checklist for reviewer
- [ ] ReadMe updated with Sniff name and link to docs in Wiki
- [ ] Unit test(s) added
- [ ] Disallowed/Allowed code examples added

